### PR TITLE
Using 1:N relationship for Poll and PollOption

### DIFF
--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Poll < ApplicationRecord
+    has_many: :poll_options
 end


### PR DESCRIPTION
# Motivation
The relationship between poll and poll_options was not set

# Solution
Set the relationship to 1:N (One Poll: Many Options)