### PR TITLE
Set Postgres as default Production database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,5 +21,10 @@ test:
   database: db/test.sqlite3
 
 production:
-  <<: *default
-  database: db/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  database: db_production
+  pool: 5
+  username: postgres
+  password:
+  timeout: 5000


### PR DESCRIPTION
# Motivaiton:
We need a PostgresSQL database to deploy to Heroku

# Solution
Use postgres as default on Production