### PR TITLE
Using postgres database url to heroku

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,10 +21,5 @@ test:
   database: db/test.sqlite3
 
 production:
-  adapter: postgresql
-  encoding: unicode
-  database: db_production
-  pool: 5
-  username: postgres
-  password:
-  timeout: 5000
+  url: <%= ENV["DATABASE_URL"] %>
+  pool: 15


### PR DESCRIPTION
# Motivation
Heroku receives a DATABASE_URL variable as Postgres URL

# Solution
Using URL instead of splitted credentials